### PR TITLE
armv7l-linux build vm for aarch64-linux machines

### DIFF
--- a/armv7.nix
+++ b/armv7.nix
@@ -1,0 +1,89 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.packet-nix-builder.armv7;
+
+  inherit (lib) mkIf mkEnableOption;
+in
+
+{
+  options = {
+    packet-nix-builder.armv7 = {
+      enable = mkEnableOption "Enable armv7l build vm";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.armv7-builder = {
+      isSystemUser = true;
+    };
+
+    services.managedVMs.armv7 = {
+      machine = "virt,highmem=off,gic-version=3";
+      cpu = "host,aarch64=off";
+      smp = 16;
+      mem = "32g";
+      rootFilesystemSize = "128g";
+      forwardPorts = [
+        { hostPort = 2200; vmPort = 22; protocol = "tcp"; }
+        { hostPort = 9101; vmPort = 9100; protocol = "tcp"; }
+      ];
+      user = "armv7-builder";
+      config = { pkgs, ... }: {
+        imports = [
+          ./user.nix
+          ./services.nix
+        ];
+
+        nixpkgs.crossSystem = { system = "armv7l-linux"; };
+
+        swapDevices = [
+          { device = "/var/swapfile"; size = 8192; }
+        ];
+
+        boot.kernelPackages = pkgs.linuxPackages_latest;
+
+        boot.kernelPatches = [
+          {
+            name = "enable-lpae";
+            patch = null;
+            extraConfig = ''
+              ARM_LPAE y
+            '';
+          }
+        ];
+        systemd.tmpfiles.rules = [
+          "d '/run/state/ssh' - root - - -"
+        ];
+
+        systemd.services.export-host-key = {
+          wantedBy = [ "multi-user.target" ];
+          path = with pkgs; [ utillinux ];
+          serviceConfig = {
+            Type = "simple";
+            Restart = "on-failure";
+            RestartSec = "5s";
+          };
+          script = ''
+            set -eux
+            set -o pipefail
+
+            if [ ! -f /etc/ssh/ssh_host_ed25519_key.pub ]; then
+              exit 1
+            fi
+
+            cp /etc/ssh/ssh_host_ed25519_key.pub /run/state/ssh
+          '';
+        };
+      };
+    };
+
+    packet-nix-builder.hostKeys = [{
+      system = "armv7l-linux";
+      port = 2200;
+      keyFile = "/var/lib/vm-armv7/ssh/ssh_host_ed25519_key.pub";
+    }];
+
+    networking.firewall.allowedTCPPorts = [ 2200 9101 ];
+  };
+}

--- a/instances/c2.large.arm.nix
+++ b/instances/c2.large.arm.nix
@@ -31,5 +31,7 @@
       '';
       */
     };
+
+    packet-nix-builder.armv7.enable = true;
   };
 }

--- a/make-netboot.nix
+++ b/make-netboot.nix
@@ -20,6 +20,7 @@ in makeNetboot ({
   imports = [
     hardware
     ./user.nix
+    ./services.nix
     ./system.nix
     ./netboot.nix
   ];

--- a/make-netboot.nix
+++ b/make-netboot.nix
@@ -23,5 +23,7 @@ in makeNetboot ({
     ./services.nix
     ./system.nix
     ./netboot.nix
+    ./managed-vm.nix
+    ./armv7.nix
   ];
 })

--- a/managed-vm.nix
+++ b/managed-vm.nix
@@ -1,0 +1,238 @@
+{ config, lib, pkgs, ... }:
+
+let
+  managedVMConfig = { config, lib, pkgs, modulesPath, ... }: {
+    imports = [
+      (modulesPath + "/profiles/qemu-guest.nix")
+    ];
+
+    config = {
+      boot.loader.grub.enable = false;
+
+      boot.kernelParams = [ "console=ttyAMA0,115200" ];
+
+      system.build.tarStore = pkgs.callPackage ./tar-store.nix {
+        storeContents = [ config.system.build.toplevel ];
+      };
+
+      fileSystems = {
+        "/" = {
+          device = "/dev/disk/by-id/virtio-scratch";
+          fsType = "ext4";
+        };
+
+        "/run/state" = {
+          device = "state";
+          fsType = "9p";
+          options = [ "trans=virtio" "version=9p2000.L" "cache=loose" ];
+        };
+      };
+
+      boot.initrd.extraUtilsCommands = ''
+        copy_bin_and_libs ${pkgs.xz}/bin/xz
+        copy_bin_and_libs ${pkgs.e2fsprogs}/bin/mke2fs
+      '';
+
+      boot.initrd.postDeviceCommands = ''
+        mke2fs -t ext4 -L scratch /dev/disk/by-id/virtio-scratch
+      '';
+
+      boot.initrd.postMountCommands = ''
+        mkdir -p $targetRoot/etc
+        echo -n > $targetRoot/etc/NIXOS
+
+        echo "Extracting initial store"
+        mkdir -p $targetRoot/nix
+        xz -d -T0 < /dev/disk/by-id/virtio-store | time tar -C $targetRoot -x
+      '';
+
+      boot.postBootCommands = ''
+        # After booting, register the contents of the Nix store
+        # in the Nix database in the scratch drive.
+        ${config.nix.package}/bin/nix-store --load-db < /nix/store/nix-path-registration
+      '';
+
+      # Pretty heavy dependency for a vm
+      services.udisks2.enable = false;
+    };
+  };
+
+  minimalConfig = {
+    programs.command-not-found.enable = false;
+    security.polkit.enable = false;
+    services.udisks2.enable = false;
+    documentation.enable = false;
+    environment.noXlibs = true;
+  };
+
+  mkManagedVM = configuration: (import (pkgs.path + "/nixos")) {
+    inherit configuration;
+  };
+in
+
+let
+  inherit (lib)
+    mkMerge flip mapAttrsToList mkOption concatStringsSep types makeBinPath
+    optionalString optionals;
+
+  managedVMConfigType = types.submodule {
+    options = {
+      cpu = mkOption {
+        type = types.str;
+        description = "QEMU -cpu option";
+        default = "host";
+        example = "host,aarch64=off";
+      };
+
+      machine = mkOption {
+        type = types.str;
+        description = "QEMU -machine option";
+        default = "virt";
+        example = "virt,highmem=off,gic-version=3";
+      };
+
+      smp = mkOption {
+        type = types.either types.int types.str;
+        description = "QEMU -smp option";
+        default = 1;
+        example = 16;
+      };
+
+      mem = mkOption {
+        type = types.str;
+        description = "QEMU -mem option";
+        default = "1g";
+        example = "8g";
+      };
+
+      minimal = mkOption {
+        type = types.bool;
+        description = "Minimize build packages and dependencies";
+        default = true;
+        example = false;
+      };
+
+      # TODO: what is the type of nixos config?
+      config = mkOption {
+        description = "NixOS configuration for the VM";
+        default = {};
+      };
+
+      consolePort = mkOption {
+        type = types.nullOr types.port;
+        default = null;
+      };
+
+      user = mkOption {
+        type = types.str;
+        description = "User to run qemu";
+      };
+
+      rootFilesystemSize = mkOption {
+        description = "Size of root filesystem, allocated with qemu-img";
+        type = types.str;
+        example = "128g";
+        default = "4g";
+      };
+
+      forwardPorts = mkOption {
+        type = types.listOf (types.submodule {
+          options = {
+            hostPort = mkOption {
+              type = types.port;
+            };
+
+            vmPort = mkOption {
+              type = types.port;
+            };
+
+            protocol = mkOption {
+              type = types.enum [ "tcp" "udp" ];
+            };
+          };
+        });
+        default = [];
+      };
+    };
+  };
+in
+
+{
+  options = {
+    services.managedVMs = mkOption {
+      default = {};
+      type = types.attrsOf managedVMConfigType;
+    };
+  };
+
+  config = {
+    systemd.services = mkMerge (flip mapAttrsToList config.services.managedVMs (name: cfg:
+      let
+        vmNixos = mkManagedVM {
+          imports = [ managedVMConfig cfg.config ] ++ optionals cfg.minimal [ minimalConfig ];
+        };
+        vmConfig = vmNixos.config;
+        kernelTarget = vmNixos.pkgs.stdenv.hostPlatform.platform.kernelTarget;
+
+        netdev = concatStringsSep "," (
+          [ "user" "id=user.0" ] ++
+          (flip map cfg.forwardPorts ({ protocol, vmPort, hostPort, ... }:
+            "hostfwd=${protocol}:0.0.0.0:${toString hostPort}-:${toString vmPort}"
+          )));
+      in {
+        "vm@${name}" = {
+          wantedBy = [ "multi-user.target" ];
+          script = ''
+            set -euo pipefail
+
+            export PATH=${makeBinPath [ pkgs.qemu_kvm ]}:$PATH
+
+            : ''${STATEDIR:=/var/lib/vm-${name}}
+            : ''${TMPDIR:=/tmp}
+
+            qemu-img create -f qcow2 $TMPDIR/scratch.qcow2 ${cfg.rootFilesystemSize}
+
+            serial=""
+            ${optionalString (cfg.consolePort != null) ''
+              if ! [ -t 1 ]; then
+                serial="telnet:localhost:${toString cfg.consolePort},server,nowait"
+              fi
+            ''}
+
+            if [ -z "$serial" ]; then
+              serial="chardev:char0"
+            fi
+
+            exec qemu-system-${pkgs.stdenv.hostPlatform.qemuArch} \
+              -kernel ${vmConfig.system.build.kernel}/${kernelTarget} \
+              -initrd ${vmConfig.system.build.initialRamdisk}/initrd \
+              -append "init=${vmConfig.system.build.toplevel}/init ${toString vmConfig.boot.kernelParams}" \
+              -machine ${cfg.machine} -cpu ${cfg.cpu} -smp ${toString cfg.smp} \
+              -m ${cfg.mem} -enable-kvm \
+              -nographic \
+              -device virtio-rng-pci \
+              -drive if=none,id=hd0,file=${vmConfig.system.build.tarStore},format=raw,readonly, \
+              -device virtio-blk-pci,drive=hd0,serial=store \
+              -drive if=none,id=hd1,file=$TMPDIR/scratch.qcow2,format=qcow2,werror=report,cache.direct=on,cache=unsafe,aio=native \
+              -device virtio-blk-pci,drive=hd1,serial=scratch \
+              -fsdev local,id=state,path=$STATEDIR,security_model=none \
+              -device virtio-9p-pci,fsdev=state,mount_tag=state \
+              -net nic,netdev=user.0,model=virtio \
+              -netdev ${netdev} \
+              -chardev stdio,mux=on,id=char0 \
+              -mon chardev=char0,mode=readline \
+              -serial "$serial" \
+              "''${extra_args[@]}"
+          '';
+
+          serviceConfig = {
+            User = cfg.user;
+            StateDirectory = "vm-%i";
+            Type = "simple";
+            PrivateTmp = true;
+          };
+        };
+      }
+    ));
+  };
+}

--- a/services.nix
+++ b/services.nix
@@ -1,0 +1,19 @@
+{
+  nixpkgs.config.allowUnfree = true;
+  services.openssh.enable = true;
+
+  networking.hostId = "00000000";
+  nix = {
+    nrBuildUsers = 100;
+    gc = {
+      automatic = true;
+      dates = "*:0/30";
+    };
+  };
+
+  networking.firewall.allowedTCPPorts = [ 9100 ];
+  services.prometheus.exporters.node = {
+    enable = true;
+    enabledCollectors = [ "systemd" ];
+  };
+}

--- a/system.nix
+++ b/system.nix
@@ -28,24 +28,7 @@ in {
   boot.supportedFilesystems = [ "zfs" ];
   boot.initrd.postDeviceCommands = "${post-device-cmds}";
 
-  nixpkgs.config.allowUnfree = true;
   hardware.enableAllFirmware = true;
-  services.openssh.enable = true;
-
-  networking.hostId = "00000000";
-  nix = {
-    nrBuildUsers = 100;
-    gc = {
-      automatic = true;
-      dates = "*:0/30";
-    };
-  };
-
-  networking.firewall.allowedTCPPorts = [ 9100 ];
-  services.prometheus.exporters.node = {
-    enable = true;
-    enabledCollectors = [ "systemd" ];
-  };
 
   systemd.services.metadata-setup-ipv6 = {
     wantedBy = [ "multi-user.target" ];

--- a/tar-store.nix
+++ b/tar-store.nix
@@ -1,0 +1,26 @@
+{ stdenv, closureInfo, storeContents, xz }:
+
+# like make-squashfs.nix but for tars
+
+stdenv.mkDerivation {
+  name = "store.tar";
+
+  nativeBuildInputs = [ xz ];
+
+  buildCommand =
+    ''
+      closureInfo=${closureInfo { rootPaths = storeContents; }}
+
+      # Also include a manifest of the closures in a format suitable
+      # for nix-store --load-db.
+      mkdir -p nix/store
+      cp $closureInfo/registration nix/store/nix-path-registration
+
+      # Generate the tarball.
+      tar -c \
+        nix/store/nix-path-registration \
+        -C / \
+        $(cat $closureInfo/store-paths) \
+        | xz -T0 > $out
+    '';
+}


### PR DESCRIPTION
I've made a guess at what things are appropriate, there's room for further iteration.

Interesting points:
 - guest root filesystem is a qcow2 in a systemd PrivateTmp. This could be a raw-mapped zvol, but then it is tied to zfs. I've also used fallocate on ext4 elsewhere for the same purpose.
 - a tarball of the store is extracted early during boot
 - the guest host key is exported over 9p fs
 - the host system exports all host keys to packet's phone home server as json

example new metadata:
```json
[ { "system": "armv7l-linux", "port": 2200, "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA4JyeK3xl/1mh8rYud5tKViO35nxzv7aABDydAvic3l root@nixos" }, 
{ "system": "aarch64-linux", "port": 22, "key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID445LxEnzOSSthRtyQFUgvxR4p/FY7j+NgYQZPzOV1Y root@nixos" } ]
```

While I was here, I applied the store tarball to the overall machine to avoid having to build a squashfs.

Things that need review or thought before deploying:
 - [ ] [hydra-packet-importer][] needs updating for metadata including multiple machines per host
 - [ ] guest/host resource allocation:
   - [ ] values for `max-jobs` and `cores` in the host and guest
   - [ ] filesystem size for guest
   - [ ] guest `nix.gc.options` `max-freed`

[hydra-packet-importer]: https://github.com/NixOS/nixos-org-configurations/blob/master/hydra-packet-importer/