### PR TITLE
tar-store: fix uid and gid

### DIFF
--- a/tar-store.nix
+++ b/tar-store.nix
@@ -17,7 +17,10 @@ stdenv.mkDerivation {
       cp $closureInfo/registration nix/store/nix-path-registration
 
       # Generate the tarball.
-      tar -c \
+      tar \
+        --sort=name \
+        --owner=0 --group=0 --numeric-owner \
+        -c \
         nix/store/nix-path-registration \
         -C / \
         $(cat $closureInfo/store-paths) \


### PR DESCRIPTION
While I'm here, try to make reproducible by sorting the contents.

Specifically, apply both of:
 - https://wiki.debian.org/ReproducibleBuilds/UsersAndGroupsInTarballs
 - https://wiki.debian.org/ReproducibleBuilds/FileOrderInTarballs