### PR TITLE
Pin Nix to 2.13

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -73,11 +73,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1676299343,
-        "narHash": "sha256-S3lBD8BnrXmui65hztNzlIqQDPU0ZtBcGcZ6zvRkJxI=",
+        "lastModified": 1677918630,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f1f9ae6a3b31cdbc3b8fc84d07fdea26a1d2f67f",
+        "rev": "e0737778444ae0aa3baf8d6512288d3310c372ed",
+        "treeHash": "bb48e1ab7212042fe9260b5e061acd15db3bc307",
         "type": "github"
       },
       "original": {

--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -30,7 +30,7 @@ in
   };
 
   config = {
-    nix.package = pkgs.nixVersions.nix_2_11;
+    nix.package = pkgs.nixVersions.nix_2_13;
     systemd.services.nix-daemon.serviceConfig.LimitNOFILE = lib.mkForce 1048576;
     nix.gc.options = ''--max-freed "$((${toString config.nix.gbFree} * 1024**3 - 1024 * $(df -P -k /nix/store | tail -n 1 | ${pkgs.gawk}/bin/awk '{ print $4 }')))"'';
     system.extraSystemBuilderCmds = ''


### PR DESCRIPTION
2.13.3 completely fixes the writeable /etc issue, as well as includes
the fix for auto GC running into a deadlock.