### PR TITLE
Fix build, update nixpkgs, rebase tmpfs-root patch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1655642194,
-        "narHash": "sha256-PHF4K1sLixSDM7lvMpuCj4ygLHGEZFQzzGIGMhsE8K0=",
+        "lastModified": 1702755016,
+        "narHash": "sha256-avRrxBjC+z3XcKjosv6vzRlyDRNIKt/Dw7/pEzcTvYY=",
         "owner": "DeterminateSystems",
         "repo": "cpiotools",
-        "rev": "926af143c453d387b585c52d5004fb5fe70fe730",
+        "rev": "189f7f5f672eb496bbba441aca1cdb208cb592ec",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664484325,
-        "narHash": "sha256-2AD0A/dFkvtamwq+/SLvZG6578q/BAw9e/T4TdIp3sw=",
+        "lastModified": 1706048018,
+        "narHash": "sha256-9ORWhjBglA4CJi10ioQaH+f1OntVA8VIOUF+HtKA4uw=",
         "owner": "DeterminateSystems",
         "repo": "nix-netboot-serve",
-        "rev": "ae8ee4acfba0a307c3e5d0944d048153924f2282",
+        "rev": "f9563484855e71445256a625141b9c8d5441a43b",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1677918630,
-        "narHash": "sha256-XvfzkZr+GQMm+BTYvQ9gMaJ6lkd1mKSEZ6I184OP5RM=",
+        "lastModified": 1706370590,
+        "narHash": "sha256-vq8hTMHsmPkBDaLR2i3m2nSmFObWmo7YwK51KQdI6RY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e0737778444ae0aa3baf8d6512288d3310c372ed",
+        "rev": "3fb3707af869e32b0ad0676f589b16cc7711a376",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
             nix-netboot-serve.nixosModules.no-filesystem
             nix-netboot-serve.nixosModules.register-nix-store
             nix-netboot-serve.nixosModules.swap-to-disk
-            nix-netboot-serve.nixosModules.tmpfs-root
+            ./modules/tmpfs-root.nix
 
 
             module

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
             ./modules/system.nix
 
             {
-              system.stateVersion = "22.11";
+              system.stateVersion = "24.05";
               nix = {
                 gbFree = 100;
                 features = [ "kvm" "nixos-test" ];

--- a/modules/0001-mnt-add-support-for-non-rootfs-initramfs.patch
+++ b/modules/0001-mnt-add-support-for-non-rootfs-initramfs.patch
@@ -1,0 +1,150 @@
+From b01222f1a1c6da4106f725366c54b20b8e8c6808 Mon Sep 17 00:00:00 2001
+From: Ignat Korchagin <ignat@cloudflare.com>
+Date: Tue, 31 Mar 2020 13:40:17 +0100
+Subject: [PATCH] mnt: add support for non-rootfs initramfs
+
+The main need for this is to support container runtimes on stateless Linux
+system (pivot_root system call from initramfs).
+
+Normally, the task of initramfs is to mount and switch to a "real" root
+filesystem. However, on stateless systems (booting over the network) it is
+just convenient to have your "real" filesystem as initramfs from the start.
+
+This, however, breaks different container runtimes, because they usually
+use pivot_root system call after creating their mount namespace. But
+pivot_root does not work from initramfs, because initramfs runs from
+rootfs, which is the root of the mount tree and can't be unmounted.
+
+One workaround is to do:
+
+  mount --bind / /
+
+However, that defeats one of the purposes of using pivot_root in the
+cloned containers: get rid of host root filesystem, should the code somehow
+escapes the chroot.
+
+There is a way to solve this problem from userspace, but it is much more
+cumbersome:
+  * either have to create a multilayered archive for initramfs, where the
+    outer layer creates a tmpfs filesystem and unpacks the inner layer,
+    switches root and does not forget to properly cleanup the old rootfs
+  * or we need to use keepinitrd kernel cmdline option, unpack initramfs
+    to rootfs, run a script to create our target tmpfs root, unpack the
+    same initramfs there, switch root to it and again properly cleanup
+    the old root, thus unpacking the same archive twice and also wasting
+    memory, because the kernel stores compressed initramfs image
+    indefinitely.
+
+With this change we can ask the kernel (by specifying nonroot_initramfs
+kernel cmdline option) to create a "leaf" tmpfs mount for us and switch
+root to it before the initramfs handling code, so initramfs gets unpacked
+directly into the "leaf" tmpfs with rootfs being empty and no need to
+clean up anything.
+
+This also bring the behaviour in line with the older style initrd, where
+the initrd is located on some leaf filesystem in the mount tree and rootfs
+remaining empty.
+
+Co-developed-by: Graham Christensen <graham@determinate.systems>
+Signed-off-by: Graham Christensen <graham@determinate.systems>
+Tested-by: Graham Christensen <graham@determinate.systems>
+Signed-off-by: Ignat Korchagin <ignat@cloudflare.com>
+---
+ .../admin-guide/kernel-parameters.txt         |  7 +++
+ fs/namespace.c                                | 48 +++++++++++++++++++
+ 2 files changed, 55 insertions(+)
+
+diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
+index 4ad60e127e04..0c76cc7a4fc5 100644
+--- a/Documentation/admin-guide/kernel-parameters.txt
++++ b/Documentation/admin-guide/kernel-parameters.txt
+@@ -3825,6 +3825,13 @@
+ 
+ 	nomodule	Disable module load
+ 
++	nonroot_initramfs
++			[KNL] Create an additional tmpfs filesystem under rootfs
++			and unpack initramfs there instead of the rootfs itself.
++			This is useful for stateless systems, which run directly
++			from initramfs, create mount namespaces and use
++			"pivot_root" system call.
++
+ 	nopat		[X86] Disable PAT (page attribute table extension of
+ 			pagetables) support.
+ 
+diff --git a/fs/namespace.c b/fs/namespace.c
+index e04a9e9e3f14..2f93940910aa 100644
+--- a/fs/namespace.c
++++ b/fs/namespace.c
+@@ -18,6 +18,7 @@
+ #include <linux/cred.h>
+ #include <linux/idr.h>
+ #include <linux/init.h>		/* init_rootfs */
++#include <linux/init_syscalls.h> /* init_chdir, init_chroot, init_mkdir */
+ #include <linux/fs_struct.h>	/* get_fs_root et.al. */
+ #include <linux/fsnotify.h>	/* fsnotify_vfsmount_delete */
+ #include <linux/file.h>
+@@ -4403,6 +4404,49 @@ static void __init init_mount_tree(void)
+ 	set_fs_root(current->fs, &root);
+ }
+ 
++#if IS_ENABLED(CONFIG_TMPFS)
++static int __initdata nonroot_initramfs;
++
++static int __init nonroot_initramfs_param(char *str)
++{
++	if (*str)
++		return 0;
++	nonroot_initramfs = 1;
++	return 1;
++}
++__setup("nonroot_initramfs", nonroot_initramfs_param);
++
++static void __init init_nonroot_initramfs(void)
++{
++	int err;
++
++	if (!nonroot_initramfs)
++		return;
++
++	err = init_mkdir("/root", 0700);
++	if (err < 0)
++		goto out;
++
++	err = init_mount("tmpfs", "/root", "tmpfs", 0, NULL);
++	if (err)
++		goto out;
++
++	err = init_chdir("/root");
++	if (err)
++		goto out;
++
++	err = init_mount(".", "/", NULL, MS_MOVE, NULL);
++	if (err)
++		goto out;
++
++	err = init_chroot(".");
++	if (!err)
++		return;
++out:
++	pr_warn("Failed to create a non-root filesystem for initramfs\n");
++}
++#endif /* IS_ENABLED(CONFIG_TMPFS) */
++
+ void __init mnt_init(void)
+ {
+ 	int err;
+@@ -4436,6 +4480,10 @@ void __init mnt_init(void)
+ 	shmem_init();
+ 	init_rootfs();
+ 	init_mount_tree();
++
++#if IS_ENABLED(CONFIG_TMPFS)
++	init_nonroot_initramfs();
++#endif
+ }
+ 
+ void put_mnt_ns(struct mnt_namespace *ns)
+-- 
+2.43.0
+

--- a/modules/tmpfs-root.nix
+++ b/modules/tmpfs-root.nix
@@ -1,0 +1,42 @@
+# tmpfs-root
+#
+# Patch the kernel to make / in the early boot environment a tmpfs
+# instead of a rootfs.
+#
+# Without this patch, Nix and other container engines cannot use
+# pivot_root.
+{ pkgs, ... }: {
+  boot.kernelParams = [ "nonroot_initramfs" ];
+  boot.kernelPatches = [
+    {
+      name = "nonroot_initramfs";
+
+      # Linux upstream unpacks the initramfs in to the rootfs directly. This breaks
+      # pivot_root which breaks Nix's process of setting up the build sandbox. This
+      # Nix uses pivot_root even when the sandbox is disabled.
+      #
+      # This patch has been upstreamed by Ignat Korchagin <ignat@cloudflare.com> before,
+      # then updated by me and upstreamed again here:
+      #
+      # https://lore.kernel.org/all/20210914170933.1922584-2-graham@determinate.systems/T/#m433939dc30c753176404792628b9bcd64d05ed7b
+      #
+      # It is available on my Linux fork on GitHub:
+      # https://github.com/grahamc/linux/tree/v5.15-rc1-nonroot-initramfs
+      #
+      # If this patch stops applying it should be fairly easy to rebase that
+      # branch on future revisions of the kernel. If it stops being easy to
+      # rebase, we can stop building our own kernel and take a slower approach
+      # instead, proposed on the LKML: as the very first step in our init:
+      #
+      # 1. create a tmpfs at /root
+      # 2. copy everything in / to /root
+      # 3. switch_root to /root
+      #
+      # This takes extra time as it will need to copy everything, and it may use
+      # double the memory. Unsure. Hopefully this patch is merged or applies
+      # easily forever.
+      patch = ./0001-mnt-add-support-for-non-rootfs-initramfs.patch;
+
+    }
+  ];
+}

--- a/modules/user.nix
+++ b/modules/user.nix
@@ -17,9 +17,9 @@ in
 {
   security.sudo.wheelNeedsPassword = false;
   services = {
-    openssh = {
-      kbdInteractiveAuthentication = false;
-      passwordAuthentication = false;
+    openssh.settings = {
+      KbdInteractiveAuthentication = false;
+      PasswordAuthentication = false;
     };
   };
 


### PR DESCRIPTION
This should get the builds back going and updates to the latest unstable-small.

Forks the `tmpfs-root.nix` module from nix-netboot-serve, so we can rebase the patch more easily.